### PR TITLE
Issue #82 - omit cells containing copyright in Markdown

### DIFF
--- a/sst/README.md
+++ b/sst/README.md
@@ -74,6 +74,20 @@ for _ in range(1000):
 # sst_hide_output
 ```
 
+#### Special handling
+This tool implements special handling for few particular cases of words or technical elements that will be handled in 
+a characteristic way.
+
+>**Shebangs**
+> 
+>When a script contains lines, which start with `#!`, the whole line will be removed from all outputs.
+
+>**Copyright notice**
+> 
+> All markdown cells with word `copyright` (case-insensitive) will be removed from Markdown output type, while in other 
+> types it will remain.
+
+
 ## Transformation to other formats
 By default, beyond python file that is single source of truth we would like to store in the repository:
 - jupyter notebook which was not executed 

--- a/sst/src/constants.py
+++ b/sst/src/constants.py
@@ -9,3 +9,5 @@ IMAGES_DIR = 'outputs'
 
 CODE_SUFFIX = '_code_only'
 README_FILE_NAME = 'README.md'
+
+REGEX_COPYRIGHT_PATTERN = r'.*(copyright).*'

--- a/sst/src/exporter/code_exporter.py
+++ b/sst/src/exporter/code_exporter.py
@@ -1,9 +1,14 @@
 # Copyright (c) 2021 Graphcore Ltd. All rights reserved.
 import os
+import re
+from typing import Optional
 
 from nbconvert import Exporter
 from nbconvert.exporters.exporter import ResourcesDict
 from nbformat import NotebookNode
+from nbformat.v4 import new_code_cell
+
+from src.constants import REGEX_COPYRIGHT_PATTERN
 
 
 class CodeExporter(Exporter):
@@ -13,9 +18,24 @@ class CodeExporter(Exporter):
         super().__init__(**kw)
 
     def from_notebook_node(self, notebook: NotebookNode, **kwargs):
-        code_cells = [cell.source + os.linesep
-                      for cell in notebook.get('cells', [])
-                      if cell.get('cell_type') == 'code']
+        copyright_cell = self._find_first_copyright_node(notebook)
+        code_cells = [copyright_cell.source] if copyright_cell else []
+
+        code_cells = code_cells + [cell.source + os.linesep for cell in notebook.cells if cell.cell_type == 'code']
 
         py_code = os.linesep.join(code_cells)
         return py_code, ResourcesDict()
+
+    @classmethod
+    def _find_first_copyright_node(cls, notebook) -> Optional[NotebookNode]:
+        """
+        Simple search method with early exit to find the first copyright Markdown node, and transform it into
+        a code cell. This way it will be part of this exporters output.
+        """
+        pattern = re.compile(pattern=REGEX_COPYRIGHT_PATTERN, flags=re.RegexFlag.IGNORECASE)
+        for cell in notebook.cells:
+            if cell.cell_type == 'markdown' and pattern.match(cell.source):
+                code_cell = new_code_cell(source=cell.source)
+                code_cell.source = os.linesep.join([f'# {line}' for line in code_cell.source.splitlines()])
+                return code_cell
+        return None

--- a/sst/src/exporter/preprocessors.py
+++ b/sst/src/exporter/preprocessors.py
@@ -1,7 +1,11 @@
 # Copyright (c) 2021 Graphcore Ltd. All rights reserved.
+import re
+
+from nbconvert.preprocessors import RegexRemovePreprocessor
+from traitlets import Enum
 from traitlets.config import Config
 
-from src.constants import SST_HIDE_OUTPUT_TAG
+from src.constants import SST_HIDE_OUTPUT_TAG, REGEX_COPYRIGHT_PATTERN
 
 
 def configure_tag_removal_preprocessor(c: Config):
@@ -13,3 +17,26 @@ def configure_tag_removal_preprocessor(c: Config):
 def configure_extract_outputs_preprocessor(c: Config):
     c.ExtractOutputsPreprocessor.enabled = True
     return c
+
+
+def configure_copyright_regex_removal_preprocessor(c: Config):
+    c.RegexWithFlagsRemovePreprocessor.patterns = [REGEX_COPYRIGHT_PATTERN]
+    c.RegexWithFlagsRemovePreprocessor.flag = re.RegexFlag.IGNORECASE
+    c.RegexWithFlagsRemovePreprocessor.enabled = True
+    return c
+
+
+class RegexWithFlagsRemovePreprocessor(RegexRemovePreprocessor):
+    """
+    Extending the nbconvert class because it does not support flags and because it compiles all patterns into one,
+    normal annotators like (?i) will not work, because they have to be at the start of a pattern.
+    """
+    flag = Enum(values=re.RegexFlag, default_value=re.RegexFlag.UNICODE).tag(config=True)
+
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.compiled_patterns = [re.compile(pattern, flags=self.flag) for pattern in self.patterns]
+
+    def check_conditions(self, cell) -> bool:
+        matches = filter(None, [compiled_pattern.match(cell.source) for compiled_pattern in self.compiled_patterns])
+        return not list(matches)

--- a/sst/tests/static/copyright_removal.py
+++ b/sst/tests/static/copyright_removal.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""
+copyright
+"""
+"""
+Copyright
+"""
+"""
+Copyright copyright
+"""
+"""
+aawe;aweawieapweaoij2908r32848ujchoehjqwovpfwr38823e32Copyright33333
+"""
+"""
+aawe;aweawieapweaoij2908r32848ujchoehjqwovpfwr38823e32copyright33333
+"""
+"""
+I am the only markdown cell around here!
+"""
+print("Yes")

--- a/sst/tests/test_cli_convert.py
+++ b/sst/tests/test_cli_convert.py
@@ -116,6 +116,41 @@ def test_cli_positive_markdown_output_removal_by_tags(cli_runner_instance, tmp_p
         assert "Goodbye sunshine4!" not in actual_contents
 
 
+def test_cli_positive_markdown_output_removal_by_regex_copyright(cli_runner_instance, tmp_path):
+    example_input = STATIC_FILES / "copyright_removal.py"
+    outfile = tmp_path / 'output'
+    outfile_path = tmp_path / 'output.md'
+
+    result = cli_runner_instance.invoke(cli, [
+        'convert', '--source', example_input, "--output", outfile, "--type", "markdown", "--execute"
+    ])
+
+    print_exception(result)
+    assert result.exit_code == 0
+
+    markdown_content = outfile_path.read_text()
+    assert "I am the only markdown cell around here!" in markdown_content
+    assert "copyright" not in markdown_content
+    assert "Copyright" not in markdown_content
+
+
+def test_cli_positive_code_only_output_removal_by_regex_copyright(cli_runner_instance, tmp_path):
+    example_input = STATIC_FILES / "copyright_removal.py"
+    outfile = tmp_path / 'output'
+    outfile_path = tmp_path / 'output.py'
+
+    result = cli_runner_instance.invoke(cli, [
+        'convert', '--source', example_input, "--output", outfile, "--type", "code", "--execute"
+    ])
+
+    print_exception(result)
+    assert result.exit_code == 0
+
+    script_content = outfile_path.read_text()
+    assert "I am the only markdown cell around here!" not in script_content
+    assert "# copyright" in script_content
+
+
 def test_cli_positive_markdown_output_extraction(cli_runner_instance, tmp_path):
     example_input = STATIC_FILES / "output_extraction.py"
     output_filename = "output.md"


### PR DESCRIPTION
Introduced `RegexWithFlagsRemovePreprocessor` extending `RegexRemovePreprocessor` because the original class lacks the functionality we needed.

Minor refactor of `markdown_exporter_with_preprocessors` to avoid code repetition.

Added more information in README about non-standard features like special handling of some words and phrases.