### PR TITLE
Issue #95 - cell output images will be stored in directory named after the source file

### DIFF
--- a/sst/README.md
+++ b/sst/README.md
@@ -103,10 +103,12 @@ sst convert2all \
 The resulting files will have the same names as the input file with a different extension, with two exceptions:
 - the Markdown output, which is either 'README.md' or custom provided name using the optional argument `markdown-name.`
 - the Python output code, in which case to avoid overwriting the source file the suffix `_code_only` will be added to it. Example result will be placed under:
+- any images rendered in cell outputs will be saved and stored in a directory named using source name as prefix and `_outputs` as suffix
 ```bash
 path_to_your_directory/XYZ.md
 path_to_your_directory/source_file_name.ipynb
 path_to_your_directory/source_file_name_code_only.py
+path_to_your_directory/source_file_name_outputs/image1.png
 ```
 
 If you would like to create each of these format files separately use:

--- a/sst/src/execute.py
+++ b/sst/src/execute.py
@@ -22,7 +22,7 @@ def execute_conversion(source: Path, output: Path, output_type: OutputTypes, exe
     output_content, resources = exporter.from_notebook_node(
         notebook,
         resources={
-            NBCONVERT_RESOURCE_OUTPUT_DIR_KEY: output.parent / f"{output.stem}-{IMAGES_DIR}"
+            NBCONVERT_RESOURCE_OUTPUT_DIR_KEY: output.parent / f"{source.stem}_{IMAGES_DIR}"
         }
     )
 

--- a/sst/tests/test_cli_convert.py
+++ b/sst/tests/test_cli_convert.py
@@ -173,7 +173,7 @@ def test_cli_positive_markdown_output_extraction(cli_runner_instance, tmp_path):
     assert len(files) == 2
     assert output_filename in files
 
-    extracted_outputs = os.listdir(outfile_path.parent / "output-outputs")
+    extracted_outputs = os.listdir(outfile_path.parent / "output_extraction_outputs")
     assert "output_1_0.png" in extracted_outputs
 
 


### PR DESCRIPTION
This change affects how the folder with cell outputs is named.
Prefix = source file name without extension
Suffix = `_outputs`

See README.md for more details

Closing #95