### PR TITLE
Issue #104 - on demand disable code only outputs

### DIFF
--- a/sst/src/batch_execution.py
+++ b/sst/src/batch_execution.py
@@ -5,7 +5,7 @@ from typing import List, Dict
 
 import yaml
 
-SSTConversionConfig = namedtuple("SSTConversionConfig", "name source markdown_name")
+SSTConversionConfig = namedtuple("SSTConversionConfig", "name source markdown_name include_code_only")
 
 
 def batch_config(config_path: Path) -> List[SSTConversionConfig]:
@@ -17,7 +17,8 @@ def batch_config(config_path: Path) -> List[SSTConversionConfig]:
         SSTConversionConfig(
             name=conversion_config.get("name", "no_name"),
             source=conversion_config.get("source", None),
-            markdown_name=conversion_config.get("markdown_name", None)
+            markdown_name=conversion_config.get("markdown_name", None),
+            include_code_only=conversion_config.get("include_code_only", True)
         )
         for conversion_config in parsed_configs
     ]

--- a/sst/src/batch_execution.py
+++ b/sst/src/batch_execution.py
@@ -5,7 +5,7 @@ from typing import List, Dict
 
 import yaml
 
-SSTConversionConfig = namedtuple("SSTConversionConfig", "name source")
+SSTConversionConfig = namedtuple("SSTConversionConfig", "name source markdown_name")
 
 
 def batch_config(config_path: Path) -> List[SSTConversionConfig]:
@@ -16,7 +16,8 @@ def batch_config(config_path: Path) -> List[SSTConversionConfig]:
     sst_conversion_configs = [
         SSTConversionConfig(
             name=conversion_config.get("name", "no_name"),
-            source=conversion_config.get("source", None)
+            source=conversion_config.get("source", None),
+            markdown_name=conversion_config.get("markdown_name", None)
         )
         for conversion_config in parsed_configs
     ]
@@ -27,6 +28,6 @@ def batch_config(config_path: Path) -> List[SSTConversionConfig]:
     return sst_conversion_configs
 
 
-def _parse_config(config_path: Path) -> List[Dict[str, str]]:
+def _parse_config(config_path: Path) -> Dict:
     with open(config_path) as f:
         return yaml.load(f,  yaml.SafeLoader)

--- a/sst/src/execute.py
+++ b/sst/src/execute.py
@@ -1,16 +1,19 @@
 # Copyright (c) 2021 Graphcore Ltd. All rights reserved.
 from pathlib import Path
+from typing import List
 
-from tqdm import tqdm
 from nbconvert.exporters.exporter import ResourcesDict
 from nbconvert.writers import FilesWriter
+from tqdm import tqdm
 
 from src.batch_execution import batch_config
-from src.constants import NBCONVERT_RESOURCE_OUTPUT_EXT_KEY, IMAGES_DIR, NBCONVERT_RESOURCE_OUTPUT_DIR_KEY
+from src.constants import NBCONVERT_RESOURCE_OUTPUT_EXT_KEY, IMAGES_DIR, \
+    NBCONVERT_RESOURCE_OUTPUT_DIR_KEY, README_FILE_NAME
 from src.exporter.factory import exporter_factory
 from src.format_converter import py_to_ipynb
-from src.output_types import supported_types, OutputTypes
-from src.utils.file import set_output_extension_and_type, output_path_code
+from src.output_types import OutputTypes
+from src.utils.file import output_path_code, \
+    output_path_markdown, output_path_jupyter
 from src.utils.logger import get_logger
 
 logger = get_logger()
@@ -53,19 +56,67 @@ def save_conversion_results(output: Path, output_content: str, resources: Resour
     writer.write(output=output_content, resources=resources, notebook_name=str(output.name))
 
 
-def execute_multiple_conversions(source_directory: Path, output_directory: Path, config_path: Path, execute: bool):
-    conversion_configs = batch_config(config_path)
-    output_directory.mkdir(parents=True, exist_ok=True)
+def execute_multiple_conversions(
+        source_directory: Path,
+        output_directory: Path,
+        config_path: Path,
+        execute: bool,
+        include_code_output: bool) -> None:
 
-    for tc in tqdm(conversion_configs, desc="SST All Configs", leave=True):
-        for supported_type in tqdm(supported_types(), desc="SST Config", leave=False):
-            output, output_type = set_output_extension_and_type(output_directory / tc.name, supported_type)
+    for tc in tqdm(batch_config(config_path), desc="SST All Configs"):
+        source = source_directory / tc.source
+        markdown_name = tc.markdown_name
 
-            output = output_path_code(output) if output_type == OutputTypes.CODE_TYPE else output
+        tc_output = output_directory / tc.name
+        tc_output.mkdir(parents=True, exist_ok=True)
 
-            execute_conversion(
-                execute=execute if supported_type is OutputTypes.MARKDOWN_TYPE else False,
-                output=output,
-                source=source_directory / tc.source,
-                output_type=output_type
-            )
+        conversion_config = prepare_conversion_config(
+            source=source,
+            output_dir=tc_output,
+            include_code_output=include_code_output,
+            markdown_name=markdown_name if markdown_name else README_FILE_NAME,
+            execute=execute
+        )
+        convert_to_outputs(source=source, configuration=conversion_config)
+
+
+def convert_to_outputs(source: Path, configuration: List) -> None:
+    for outfile, output_type, execution in tqdm(configuration, desc="SST Config", leave=False):
+        execute_conversion(
+            source=source,
+            output=outfile,
+            output_type=output_type,
+            execute=execution
+        )
+
+
+def prepare_conversion_config(
+        source: Path,
+        output_dir: Path,
+        execute: bool,
+        include_code_output: bool,
+        markdown_name: str
+) -> List:
+
+    assert source.suffix == '.py', 'Only python file can be single source file'
+
+    if output_dir is None:
+        output_dir = source.parent
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_filename = output_dir / source.stem
+
+    markdown_filename = output_dir / markdown_name
+
+    configuration = [
+        [output_path_markdown(markdown_filename), OutputTypes.MARKDOWN_TYPE, execute],
+        [output_path_jupyter(output_filename), OutputTypes.JUPYTER_TYPE, False]
+    ]
+
+    if include_code_output:
+        configuration.append(
+            [output_path_code(output_filename), OutputTypes.CODE_TYPE, False]
+        )
+
+    return configuration

--- a/sst/src/execute.py
+++ b/sst/src/execute.py
@@ -60,8 +60,7 @@ def execute_multiple_conversions(
         source_directory: Path,
         output_directory: Path,
         config_path: Path,
-        execute: bool,
-        include_code_output: bool) -> None:
+        execute: bool) -> None:
 
     for tc in tqdm(batch_config(config_path), desc="SST All Configs"):
         source = source_directory / tc.source
@@ -73,7 +72,7 @@ def execute_multiple_conversions(
         conversion_config = prepare_conversion_config(
             source=source,
             output_dir=tc_output,
-            include_code_output=include_code_output,
+            include_code_output=tc.include_code_only,
             markdown_name=markdown_name if markdown_name else README_FILE_NAME,
             execute=execute
         )

--- a/sst/src/output_types.py
+++ b/sst/src/output_types.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2021 Graphcore Ltd. All rights reserved.
 from enum import Enum
+from typing import List
 
 
-def supported_types():
+def supported_types() -> List:
     return list(OutputTypes)
 
 

--- a/sst/sst.py
+++ b/sst/sst.py
@@ -2,11 +2,11 @@
 from pathlib import Path
 
 import click
-from tqdm import tqdm
 
-from src.execute import execute_conversion, execute_multiple_conversions
+from src.execute import execute_conversion, execute_multiple_conversions, \
+    convert_to_outputs, prepare_conversion_config
 from src.output_types import OutputTypes, supported_types
-from src.utils.file import set_output_extension_and_type, output_path_jupyter, output_path_code, output_path_markdown
+from src.utils.file import set_output_extension_and_type
 from src.constants import README_FILE_NAME
 
 
@@ -44,28 +44,20 @@ def convert(source: Path, output: Path, type: OutputTypes, execute: bool) -> Non
               help='Absolute or relative path to output directory.')
 @click.option('--markdown-name', '-m', required=False, type=Path, default=README_FILE_NAME,
               help='Custom name for output Markdown file.')
-def convert2all(source: Path, output_dir: Path, markdown_name: str) -> None:
+@click.option('--include-code-output/--exclude-code-output', required=False, type=bool, default=True,
+              help='Flag deciding if the code-only output should be exported.')
+def convert2all(source: Path, output_dir: Path, markdown_name: str, include_code_output: bool) -> None:
     """
     Transforms source python file automatically into three specified formats with specified configuration:
     jupyter notebook, executed markdown file and python code script.
     """
-    assert source.suffix == '.py', 'Only python file can be single source file'
-    if output_dir is None:
-        output_dir = source.parent
-    output_dir.mkdir(parents=True, exist_ok=True)
+    configuration = prepare_conversion_config(source=source,
+                                              output_dir=output_dir,
+                                              execute=True,
+                                              include_code_output=include_code_output,
+                                              markdown_name=markdown_name)
 
-    output_filename = output_dir / source.stem
-
-    markdown_filename = output_dir / markdown_name
-
-    configuration = [
-        [output_path_markdown(markdown_filename), OutputTypes.MARKDOWN_TYPE, True],
-        [output_path_code(output_filename), OutputTypes.CODE_TYPE, False],
-        [output_path_jupyter(output_filename), OutputTypes.JUPYTER_TYPE, False]
-    ]
-
-    for outfile, output_type, execution in tqdm(configuration):
-        execute_conversion(source=source, output=outfile, output_type=output_type, execute=execution)
+    convert_to_outputs(source=source, configuration=configuration)
 
 
 @cli.command()
@@ -77,15 +69,19 @@ def convert2all(source: Path, output_dir: Path, markdown_name: str) -> None:
 @click.option('--output-dir', '-o', required=True, type=Path,
               help='Absolute or relative path to output directory for all files')
 @click.option('--execute/--no-execute', default=True, help='Flag whether the notebook is to be executed or not')
-def batch_convert(config: Path, source_dir: Path, output_dir: Path, execute: bool) -> None:
+@click.option('--include-code-output/--exclude-code-output', required=False, type=bool, default=True,
+              help='Flag deciding if the code-only output should be exported.')
+def batch_convert(config: Path, source_dir: Path, output_dir: Path, execute: bool, include_code_output: bool) -> None:
     """
-    Transforms python files specified in config into all possible formats: jupyter notebook, markdown and python code
+    Transforms python files specified in config into all possible formats: jupyter notebook, markdown and python code.
+    Each source will get it's own output directory under the 'output_dir'.
     """
     execute_multiple_conversions(
         source_directory=source_dir,
         output_directory=output_dir,
         config_path=config,
-        execute=execute
+        execute=execute,
+        include_code_output=include_code_output
     )
 
 

--- a/sst/sst.py
+++ b/sst/sst.py
@@ -69,9 +69,7 @@ def convert2all(source: Path, output_dir: Path, markdown_name: str, include_code
 @click.option('--output-dir', '-o', required=True, type=Path,
               help='Absolute or relative path to output directory for all files')
 @click.option('--execute/--no-execute', default=True, help='Flag whether the notebook is to be executed or not')
-@click.option('--include-code-output/--exclude-code-output', required=False, type=bool, default=True,
-              help='Flag deciding if the code-only output should be exported.')
-def batch_convert(config: Path, source_dir: Path, output_dir: Path, execute: bool, include_code_output: bool) -> None:
+def batch_convert(config: Path, source_dir: Path, output_dir: Path, execute: bool) -> None:
     """
     Transforms python files specified in config into all possible formats: jupyter notebook, markdown and python code.
     Each source will get it's own output directory under the 'output_dir'.
@@ -80,8 +78,7 @@ def batch_convert(config: Path, source_dir: Path, output_dir: Path, execute: boo
         source_directory=source_dir,
         output_directory=output_dir,
         config_path=config,
-        execute=execute,
-        include_code_output=include_code_output
+        execute=execute
     )
 
 

--- a/sst/tests/static/conversion_config.yml
+++ b/sst/tests/static/conversion_config.yml
@@ -1,5 +1,6 @@
 files:
   - name: File1
     source: tests/static/trivial_mapping_md_code_md.py
+    markdown_name: DONT_README.md
   - name: File2
     source: tests/static/py_with_import.py

--- a/sst/tests/static/conversion_config.yml
+++ b/sst/tests/static/conversion_config.yml
@@ -4,3 +4,6 @@ files:
     markdown_name: DONT_README.md
   - name: File2
     source: tests/static/py_with_import.py
+  - name: File3
+    source: tests/static/just_py_method.py
+    include_code_only: False

--- a/sst/tests/test_cli_batch_convert.py
+++ b/sst/tests/test_cli_batch_convert.py
@@ -36,7 +36,11 @@ def test_cli_batch_convert(cli_runner_instance, tmp_path):
     assert result.exit_code == 0
     assert len(os.listdir(output_dir / "File1")) == 3
     assert os.path.exists(output_dir / "File1" / 'DONT_README.md')
+
     assert len(os.listdir(output_dir / "File2")) == 3
+
+    assert len(os.listdir(output_dir / "File3")) == 2
+    assert not os.path.exists(output_dir / "File3" / 'just_py_method_code_only.py')
 
 
 @pytest.mark.parametrize("config_path", ['conversion_config_incorrect.yml', 'conversion_config_empty.yml'])

--- a/sst/tests/test_cli_batch_convert.py
+++ b/sst/tests/test_cli_batch_convert.py
@@ -24,15 +24,19 @@ def test_cli_batch_convert(cli_runner_instance, tmp_path):
     source_dir = STATIC_FILES.parent.parent
 
     result = cli_runner_instance.invoke(cli, ['batch-convert',
-                                              '--config', example_config, "--output-dir", output_dir, "--source-dir",
-                                              source_dir, "--no-execute"
+                                              '--config', example_config,
+                                              "--output-dir", output_dir,
+                                              "--source-dir",
+                                              source_dir,
+                                              "--no-execute"
                                               ])
 
     print_exception(result)
 
     assert result.exit_code == 0
-
-    assert len(os.listdir(output_dir)) == 6
+    assert len(os.listdir(output_dir / "File1")) == 3
+    assert os.path.exists(output_dir / "File1" / 'DONT_README.md')
+    assert len(os.listdir(output_dir / "File2")) == 3
 
 
 @pytest.mark.parametrize("config_path", ['conversion_config_incorrect.yml', 'conversion_config_empty.yml'])

--- a/sst/tests/test_cli_convert2all.py
+++ b/sst/tests/test_cli_convert2all.py
@@ -77,3 +77,31 @@ def test_cli_convert2all_when_no_output_dir_and_default_markdown_name(cli_runner
     assert os.path.exists(markdown_file_path.with_suffix('.md'))
     assert os.path.exists(outfile_path.with_suffix('.ipynb'))
     assert os.path.exists(outfile_path.with_name('my_file_code_only.py'))
+
+
+def test_cli_convert2all_when_excluding_code_output(cli_runner_instance, tmp_path):
+    result = cli_runner_instance.invoke(
+        cli,
+        [
+            'convert2all',
+            '--source', TRIVIAL_MAPPING_SOURCE_PATH,
+            '--output-dir', tmp_path,
+            '--markdown-name', 'trivial_mapping_md_code_md',
+            '--exclude-code-output'
+        ]
+    )
+    print_exception(result)
+
+    outfile_path = tmp_path / Path('trivial_mapping_md_code_md')
+
+    for file_name in [
+        outfile_path.with_suffix('.md'),
+        outfile_path.with_suffix('.ipynb')
+    ]:
+        assert os.path.exists(file_name)
+
+    assert not os.path.exists(
+        outfile_path.with_name('trivial_mapping_md_code_md_code_only.py')
+    )
+
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary of changes
Adding the optional flag:
`--include-code-output/--exclude-code-output`

This flag is deciding if the code-only output should be exported or not.

## Example
`sst convert2all -s script.py -o . --exclude-code-output` -> will yield 2 files (jupyter and markdown)
`sst convert2all -s script.py -o . --include-code-output` -> will yield 3 files (jupyter, markdown and Python code only)
`sst convert2all -s script.py -o . ` -> behaves as before, will yield 3 files (jupyter, markdown and Python code only)

### Tickets
Closing #104 